### PR TITLE
Implement FindRows with an iterator

### DIFF
--- a/db/dao.go
+++ b/db/dao.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"iter"
 	"strings"
 	"time"
 )
@@ -67,31 +68,42 @@ func GetColumn[T Column](ctx context.Context, q string, args ...any) (T, error) 
 	return t, nil
 }
 
+func errIter[T any](err error) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		var t T
+		yield(t, err)
+	}
+}
+
 // FindRows executes q as a query, and returns rows as type []T.
 // T must implement a ToPtrArgs method with a pointer receiver type.
-func FindRows[T any, PT Row[T]](ctx context.Context, q string, args ...any) ([]T, error) {
+func FindRows[T any, PT Row[T]](ctx context.Context, q string, args ...any) iter.Seq2[T, error] {
 	rows, err := database.QueryContext(ctx, q, args...)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
+			return nil
 		}
-		return nil, fmt.Errorf("DAO#FindRows QueryContext failed\n%s: %w", q, err)
+		return errIter[T](fmt.Errorf("DAO#FindRows QueryContext failed\n%s: %w", q, err))
 	}
-	defer func() { _ = rows.Close() }()
 
-	var result []T
-	for rows.Next() {
-		var t T
-		ptr := PT(&t)
-		if err := rows.Scan(ptr.PtrFields()...); err != nil {
-			return nil, fmt.Errorf("DAO#FindRows row.Scan error\n%s: %w", q, err)
+	return func(yield func(T, error) bool) {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var t T
+			ptr := PT(&t)
+			if err := rows.Scan(ptr.PtrFields()...); err != nil {
+				yield(t, fmt.Errorf("DAO#FindRows row.Scan error\n%s: %w", q, err))
+				break
+			}
+			if !yield(t, nil) {
+				break
+			}
 		}
-		result = append(result, t)
+		if err := rows.Err(); err != nil {
+			var t T
+			yield(t, fmt.Errorf("DAO#FindRows rows.Err()\n%s: %w", q, err))
+		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("DAO#FindRows rows.Err()\n%s: %w", q, err)
-	}
-	return result, nil
 }
 
 // FindColumns executes q as a query, and returns rows as type []T.

--- a/db/dao.go
+++ b/db/dao.go
@@ -68,7 +68,7 @@ func GetColumn[T Column](ctx context.Context, q string, args ...any) (T, error) 
 	return t, nil
 }
 
-// FindRows executes q as a query, and returns rows as type []T.
+// FindRows executes q as a query, and returns an iterator of type (T, error).
 // T must implement a ToPtrArgs method with a pointer receiver type.
 func FindRows[T any, PT Row[T]](ctx context.Context, q string, args ...any) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {
@@ -82,12 +82,13 @@ func FindRows[T any, PT Row[T]](ctx context.Context, q string, args ...any) iter
 			return
 		}
 		defer func() { _ = rows.Close() }()
+
 		for rows.Next() {
 			var t T
 			ptr := PT(&t)
 			if err := rows.Scan(ptr.PtrFields()...); err != nil {
 				yield(t, fmt.Errorf("DAO#FindRows row.Scan error\n%s: %w", q, err))
-				break
+				return
 			}
 			if !yield(t, nil) {
 				break
@@ -100,30 +101,36 @@ func FindRows[T any, PT Row[T]](ctx context.Context, q string, args ...any) iter
 	}
 }
 
-// FindColumns executes q as a query, and returns rows as type []T.
+// FindColumns executes q as a query, and returns an iterator of type (T, error).
 // T must satisfy the Column constraint.
-func FindColumns[T Column](ctx context.Context, q string, args ...any) ([]T, error) {
-	rows, err := database.QueryContext(ctx, q, args...)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
+func FindColumns[T Column](ctx context.Context, q string, args ...any) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		rows, err := database.QueryContext(ctx, q, args...)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return // empty iterator
+			}
+			var t T
+			yield(t, fmt.Errorf("DAO#FindColumns QueryContext failed\n%s: %w", q, err))
+			return
 		}
-		return nil, fmt.Errorf("DAO#FindColumns QueryContext failed\n%s: %w", q, err)
-	}
-	defer func() { _ = rows.Close() }()
+		defer func() { _ = rows.Close() }()
 
-	var result []T
-	for rows.Next() {
-		var t T
-		if err := rows.Scan(&t); err != nil {
-			return nil, fmt.Errorf("DAO#FindColumns row.Scan error\n%s: %w", q, err)
+		for rows.Next() {
+			var t T
+			if err := rows.Scan(&t); err != nil {
+				yield(t, fmt.Errorf("DAO#FindColumns row.Scan error\n%s: %w", q, err))
+				return
+			}
+			if !yield(t, nil) {
+				break
+			}
 		}
-		result = append(result, t)
+		if err := rows.Err(); err != nil {
+			var t T
+			yield(t, fmt.Errorf("DAO#FindColumns rows.Err()\n%s: %w", q, err))
+		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("DAO#FindColumns rows.Err()\n%s: %w", q, err)
-	}
-	return result, nil
 }
 
 // InArgs returns placeholders and args formatted for a WHERE IN clause.

--- a/like/like_dao.go
+++ b/like/like_dao.go
@@ -2,6 +2,7 @@ package like
 
 import (
 	"context"
+	"iter"
 
 	"github.com/Jimeux/go-generic-dao/db"
 )
@@ -30,6 +31,6 @@ func (DAO) Count(ctx context.Context) (int64, error) {
 
 const findByUserQuery = "SELECT " + Columns + " FROM " + Table + " WHERE `user_id` = ? ORDER BY `id`;"
 
-func (DAO) FindByUser(ctx context.Context, userID int64) ([]Like, error) {
+func (DAO) FindByUser(ctx context.Context, userID int64) iter.Seq2[Like, error] {
 	return db.FindRows[Like](ctx, findByUserQuery, userID)
 }

--- a/like/like_dao_test.go
+++ b/like/like_dao_test.go
@@ -127,8 +127,7 @@ func TestLikeDAO_FindByUser(t *testing.T) {
 
 		want := []Like{like1, like2}
 		var got []Like
-		iter := dao.FindByUser(ctx, like2.UserID)
-		for u, err := range iter {
+		for u, err := range dao.FindByUser(ctx, like2.UserID) {
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -140,8 +139,7 @@ func TestLikeDAO_FindByUser(t *testing.T) {
 	})
 	t.Run("not found", func(t *testing.T) {
 		t.Cleanup(test.Truncate(t, Table))
-		iter := dao.FindByUser(ctx, 1000)
-		for got, err := range iter {
+		for got, err := range dao.FindByUser(ctx, 1000) {
 			t.Fatalf("want empty iterator, got %v, %v", got, err)
 		}
 	})

--- a/like/like_dao_test.go
+++ b/like/like_dao_test.go
@@ -126,9 +126,13 @@ func TestLikeDAO_FindByUser(t *testing.T) {
 		}
 
 		want := []Like{like1, like2}
-		got, err := dao.FindByUser(ctx, like2.UserID)
-		if err != nil {
-			t.Fatal(err)
+		var got []Like
+		iter := dao.FindByUser(ctx, like2.UserID)
+		for u, err := range iter {
+			if err != nil {
+				t.Fatal(err)
+			}
+			got = append(got, u)
 		}
 		if !cmp.Equal(got, want) {
 			t.Fatalf(cmp.Diff(want, got))
@@ -136,12 +140,9 @@ func TestLikeDAO_FindByUser(t *testing.T) {
 	})
 	t.Run("not found", func(t *testing.T) {
 		t.Cleanup(test.Truncate(t, Table))
-		got, err := dao.FindByUser(ctx, 1000)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(got) != 0 {
-			t.Fatalf("expected got to be empty but was len=%d", len(got))
+		iter := dao.FindByUser(ctx, 1000)
+		for got, err := range iter {
+			t.Fatalf("want empty iterator, got %v, %v", got, err)
 		}
 	})
 }

--- a/like/like_dao_test.go
+++ b/like/like_dao_test.go
@@ -127,11 +127,11 @@ func TestLikeDAO_FindByUser(t *testing.T) {
 
 		want := []Like{like1, like2}
 		var got []Like
-		for u, err := range dao.FindByUser(ctx, like2.UserID) {
+		for l, err := range dao.FindByUser(ctx, like2.UserID) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got = append(got, u)
+			got = append(got, l)
 		}
 		if !cmp.Equal(got, want) {
 			t.Fatalf(cmp.Diff(want, got))

--- a/user/user.go
+++ b/user/user.go
@@ -13,7 +13,7 @@ const (
 type User struct {
 	ID        int64
 	Nickname  string
-	Bio       sql.NullString
+	Bio       sql.Null[string]
 	CreatedAt time.Time
 }
 

--- a/user/user_dao.go
+++ b/user/user_dao.go
@@ -40,6 +40,6 @@ func (DAO) FindByIDs(ctx context.Context, ids []int64) iter.Seq2[User, error] {
 
 const findIDsWithBioQuery = "SELECT `id` FROM " + Table + " WHERE `bio` IS NOT NULL;"
 
-func (DAO) FindIDsWithBio(ctx context.Context) ([]int64, error) {
+func (DAO) FindIDsWithBio(ctx context.Context) iter.Seq2[int64, error] {
 	return db.FindColumns[int64](ctx, findIDsWithBioQuery)
 }

--- a/user/user_dao.go
+++ b/user/user_dao.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"fmt"
+	"iter"
 
 	"github.com/Jimeux/go-generic-dao/db"
 )
@@ -31,7 +32,7 @@ func (DAO) Count(ctx context.Context) (int64, error) {
 
 const findByIDsQuery = "SELECT " + Columns + " FROM " + Table + " WHERE `id` IN (%s) ORDER BY `id`;"
 
-func (DAO) FindByIDs(ctx context.Context, ids []int64) ([]User, error) {
+func (DAO) FindByIDs(ctx context.Context, ids []int64) iter.Seq2[User, error] {
 	placeholders, args := db.InArgs(ids)
 	q := fmt.Sprintf(findByIDsQuery, placeholders)
 	return db.FindRows[User](ctx, q, args...)

--- a/user/user_dao_test.go
+++ b/user/user_dao_test.go
@@ -124,9 +124,13 @@ func TestUserDAO_FindByIDs(t *testing.T) {
 		}
 
 		want := []User{user1, user2}
-		got, err := dao.FindByIDs(ctx, []int64{user1.ID, user2.ID})
-		if err != nil {
-			t.Fatal(err)
+		var got []User
+		iter := dao.FindByIDs(ctx, []int64{user1.ID, user2.ID})
+		for u, err := range iter {
+			if err != nil {
+				t.Fatal(err)
+			}
+			got = append(got, u)
 		}
 		if !cmp.Equal(got, want) {
 			t.Fatalf(cmp.Diff(want, got))
@@ -134,12 +138,9 @@ func TestUserDAO_FindByIDs(t *testing.T) {
 	})
 	t.Run("not found", func(t *testing.T) {
 		t.Cleanup(test.Truncate(t, Table))
-		got, err := dao.FindByIDs(ctx, []int64{1000})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(got) != 0 {
-			t.Fatalf("expected got to be empty but was len=%d", len(got))
+		iter := dao.FindByIDs(ctx, []int64{1000})
+		for got, err := range iter {
+			t.Fatalf("want empty iterator, got %v, %v", got, err)
 		}
 	})
 }

--- a/user/user_dao_test.go
+++ b/user/user_dao_test.go
@@ -33,7 +33,7 @@ func TestUserDAO_Create(t *testing.T) {
 	ctx := context.Background()
 	dao := DAO{}
 
-	t.Run("Create", func(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
 		t.Cleanup(test.Truncate(t, Table))
 		want := defaultUser()
 		got, err := dao.Create(ctx, want)
@@ -151,9 +151,12 @@ func TestUserDAO_FindIDsWithBio(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		t.Cleanup(test.Truncate(t, Table))
-		got, err := dao.FindIDsWithBio(ctx)
-		if err != nil {
-			t.Fatal(err)
+		var got []int64
+		iter := dao.FindIDsWithBio(ctx)
+		for _, err := range iter {
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 		if len(got) != 0 {
 			t.Fatalf("expected got to be empty but was len=%d", len(got))


### PR DESCRIPTION
Implement `FindRows` and `FindColumns` with `iter.Seq2[T, error]`. 
The `for rows.Next() {...}` loop is executed inside the iterator, and Scan results are passed one by one via the `yield` function. This avoids allocating a slice for the results in advance.